### PR TITLE
v.0.0.2 api_version default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## 0.0.2
+  * Make `api_version` a default in client.py (and not a tap `config.json` parameter)
+
 ## 0.0.1
   * Initial commit

--- a/README.md
+++ b/README.md
@@ -203,12 +203,11 @@ This tap:
     - [singer-tools](https://github.com/singer-io/singer-tools)
     - [target-stitch](https://github.com/singer-io/target-stitch)
 
-3. Create your tap's `config.json` file. The `server_subdomain` is everything before `.pepperjam.com.` in the pepperjam URL.  The `account_name` is everything between `.pepperjam.com.` and `api` in the pepperjam URL. The `date_window_size` is the integer number of days (between the from and to dates) for date-windowing through the date-filtered endpoints (default = 60).
+3. Create your tap's `config.json` file. The `api_key` is available in the Pepperjam Console UI (see **Authentication** above). The `date_window_days` is the integer number of days (between the from and to dates) for date-windowing through the date-filtered endpoints (default = 30). The `lock_period_days` is the latency look-back period for reports/performance endpoints. The `start_date` is the absolute beginning date from which incremental loading on the initial load will start.
 
     ```json
     {
         "api_key": "YOUR_API_KEY",
-        "api_version": "PEPPERJAM_API_VERSION",
         "date_window_days": "30",
         "lock_period_days": "60",
         "start_date": "2019-01-01T00:00:00Z",

--- a/config.json.example
+++ b/config.json.example
@@ -1,6 +1,5 @@
 {
     "api_key": "YOUR_API_KEY",
-    "api_version": "PEPPERJAM_API_VERSION",
     "date_window_days": "30",
     "lock_period_days": "60",
     "start_date": "2019-01-01T00:00:00Z",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-pepperjam',
-      version='0.0.1',
+      version='0.0.2',
       description='Singer.io tap for extracting data from the Pepperjam Advertiser API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_pepperjam/__init__.py
+++ b/tap_pepperjam/__init__.py
@@ -13,7 +13,6 @@ LOGGER = singer.get_logger()
 
 REQUIRED_CONFIG_KEYS = [
     'api_key',
-    'api_version',
     'start_date',
     'user_agent'
 ]
@@ -32,7 +31,6 @@ def main():
     parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
 
     with PepperjamClient(parsed_args.config['api_key'],
-                         parsed_args.config['api_version'],
                          parsed_args.config['user_agent']) as client:
 
         state = {}

--- a/tap_pepperjam/client.py
+++ b/tap_pepperjam/client.py
@@ -6,6 +6,8 @@ import singer
 
 LOGGER = singer.get_logger()
 
+API_VERSION = '20120402'
+
 
 class Server5xxError(Exception):
     pass
@@ -96,15 +98,13 @@ def raise_for_error(response):
 class PepperjamClient(object):
     def __init__(self,
                  api_key,
-                 api_version,
                  user_agent=None):
         self.__api_key = api_key
-        self.__api_version = api_version
         self.__user_agent = user_agent
         self.__session = requests.Session()
         self.__verified = False
         self.base_url = 'https://api.pepperjamnetwork.com/{}/advertiser'.format(
-            api_version)
+            API_VERSION)
 
     def __enter__(self):
         self.__verified = self.check_api_key()

--- a/tap_pepperjam/streams.py
+++ b/tap_pepperjam/streams.py
@@ -19,7 +19,7 @@ STREAMS = {
         'path': 'creative/advanced',
         'key_properties': ['id'],
         'replication_method': 'INCREMENTAL',
-        'repllication_keys': ['modified'],
+        'replication_keys': ['modified'],
         'data_key': 'data',
         'params': {}
     },
@@ -29,7 +29,7 @@ STREAMS = {
         'path': 'creative/banner',
         'key_properties': ['id'],
         'replication_method': 'INCREMENTAL',
-        'repllication_keys': ['modified'],
+        'replication_keys': ['modified'],
         'data_key': 'data',
         'params': {}
     },
@@ -39,7 +39,7 @@ STREAMS = {
         'path': 'creative/coupon',
         'key_properties': ['id'],
         'replication_method': 'INCREMENTAL',
-        'repllication_keys': ['modified'],
+        'replication_keys': ['modified'],
         'data_key': 'data',
         'params': {}
     },
@@ -49,7 +49,7 @@ STREAMS = {
         'path': 'creative/generic',
         'key_properties': ['type'],
         'replication_method': 'INCREMENTAL',
-        'repllication_keys': ['modified'],
+        'replication_keys': ['modified'],
         'data_key': 'data',
         'params': {}
     },
@@ -77,7 +77,7 @@ STREAMS = {
         'path': 'creative/text',
         'key_properties': ['id'],
         'replication_method': 'INCREMENTAL',
-        'repllication_keys': ['modified'],
+        'replication_keys': ['modified'],
         'data_key': 'data',
         'params': {}
     },

--- a/tap_pepperjam/sync.py
+++ b/tap_pepperjam/sync.py
@@ -137,6 +137,8 @@ def sync_endpoint(
 
     last_datetime = get_bookmark(state, stream_name, start_date)
     max_bookmark_value = last_datetime
+    LOGGER.info('stream: {}, bookmark_field: {}, last_datetime: {}'.format(
+         stream_name, bookmark_field, last_datetime))
 
     # windowing: loop through date date_window_days date windows from last_datetime to now_datetime
     now_datetime = utils.now()


### PR DESCRIPTION
Make `api_version` a default in client.py (and not a tap `config.json` parameter)