### PR TITLE
v.0.0.5 Eastern time zone start/end dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.5
+  * Fix beta testing issues with `endDate` query parameter requesting a future date (Eastern time zone). Changed query `startDate` and `endDate` to use Eastern time zone for date windows and not UTC time.
+
 ## 0.0.4
   * Fix issue where `api_key` is appearing in logs. Fix issue where `transaction_history` date window cannot exceed 28 days.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-pepperjam',
-      version='0.0.4',
+      version='0.0.5',
       description='Singer.io tap for extracting data from the Pepperjam Advertiser API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Fix beta testing issues with `endDate` query parameter requesting a future date (Eastern time zone). Changed query `startDate` and `endDate` to use Eastern time zone for date windows and not UTC time.

# Manual QA steps
Verified error and fixed sync. Ran changes with singer-discover, singer-check-tap, and target-stitch (initial load and incremental sync) for affected endpoints. No errors.
 
# Risks
Low. Currently in beta testing. Fixes issue identified in beta testing.
 
# Rollback steps
Revert to v.0.0.4
