### PR TITLE
v.0.0.6 transaction_history PK, publisher new field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.vscode/*
+.vscode
 /.ipynb_checkpoints/*
 config/
 virtualenvs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.6
+  * Add new field `primary_promo_method` to `publishers.json` schema. Change `key_properties` for `transaction_history` in `streams.py`. Fix blank/NULL handling for `transaction_history.item_id`.
+  * **NOTE**: Clients will need to drop `transaction_history` in the target database and re-sync history. Otherwise, Stitch loads will get error: `Primary Keys for table do not match Primary Keys of incoming data`.
+
 ## 0.0.5
   * Fix beta testing issues with `endDate` query parameter requesting a future date (Eastern time zone). Changed query `startDate` and `endDate` to use Eastern time zone for date windows and not UTC time.
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ This tap:
 
 [transaction_history](https://support.pepperjam.com/s/advertiser-api-documentation#TransactionHistory)
 - Endpoint: report/transaction-history
-- Primary key fields: transaction_id, sale_date, process_date
+- Primary key fields: transaction_id, item_id, revision
 - Replication strategy: INCREMENTAL (query filtered)
    - Bookmark query fields: startDate, endDate
    - Bookmark: sale_date (date-time)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-pepperjam',
-      version='0.0.5',
+      version='0.0.6',
       description='Singer.io tap for extracting data from the Pepperjam Advertiser API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_pepperjam/schemas/.vscode/settings.json
+++ b/tap_pepperjam/schemas/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/Users/jeff.huth/.virtualenvs/tap-pepperjam/bin/python"
-}

--- a/tap_pepperjam/schemas/publisher.json
+++ b/tap_pepperjam/schemas/publisher.json
@@ -26,6 +26,9 @@
     "website": {
       "type": ["null", "string"]
     },
+    "primary_promo_method": {
+      "type": ["null", "string"]
+    },
     "status": {
       "type": ["null", "string"]
     },

--- a/tap_pepperjam/streams.py
+++ b/tap_pepperjam/streams.py
@@ -201,7 +201,7 @@ STREAMS = {
     # Reference: https://support.pepperjam.com/s/advertiser-api-documentation#TransactionHistory
     'transaction_history': {
         'path': 'report/transaction-history',
-        'key_properties': ['transaction_id', 'sale_date', 'process_date'],
+        'key_properties': ['transaction_id', 'item_id', 'revision'],
         'replication_method': 'INCREMENTAL',
         'replication_keys': ['sale_date'],
         'bookmark_query_field_from': 'startDate',

--- a/tap_pepperjam/sync.py
+++ b/tap_pepperjam/sync.py
@@ -275,12 +275,20 @@ def sync_endpoint(
                 break # No data results
 
             # Verify key id_fields are present
+            i = 0
             for record in transformed_data:
                 for key in id_fields:
+                    # Fix issue with isolated cases where item_id in NULL, empty string, etc.
+                    if stream_name == 'transaction_history' and key == 'item_id':
+                        if not record.get(key):
+                            transformed_data[i]['item_id'] = 'not_applicable'
+                        if record.get(key) is None or record.get(key) == 'NULL' or record.get(key) == '':
+                            transformed_data[i]['item_id'] = 'not_applicable'
                     if not record.get(key):
                         LOGGER.info('Stream: {}, Missing key {} in record: {}'.format(
                             stream_name, key, record))
                         raise RuntimeError
+                i = i + 1
 
             # Process records and get the max_bookmark_value and record_count for the set of records
             max_bookmark_value, record_count = process_records(


### PR DESCRIPTION
# Description of change
 Add new field `primary_promo_method` to `publishers.json` schema. Change `key_properties` for `transaction_history` in `streams.py`. Fix blank/NULL handling for `transaction_history.item_id`.
 
# Manual QA steps
Ran singer-discover, singer-check-tap, target-stitch (initial and ongoing incremental loads). No issue w/ new fields and logic. However, see **NOTE** in Risks below.
 
# Risks
Tap currently in beta. Changes requested by Pepperjam app team on behalf of beta clients. 
**NOTE**: Clients will need to drop `transaction_history` in the target database and re-sync history. Otherwise, Stitch loads will get error: `Primary Keys for table do not match Primary Keys of incoming data`.

# Rollback steps
 - revert this branch
