### PR TITLE
bumped to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.0.6
+## 1.0.0
   * Add new field `primary_promo_method` to `publishers.json` schema. Change `key_properties` for `transaction_history` in `streams.py`. Fix blank/NULL handling for `transaction_history.item_id`.
   * **NOTE**: Clients will need to drop `transaction_history` in the target database and re-sync history. Otherwise, Stitch loads will get error: `Primary Keys for table do not match Primary Keys of incoming data`.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-pepperjam',
-      version='0.0.6',
+      version='1.0.0',
       description='Singer.io tap for extracting data from the Pepperjam Advertiser API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
#5 bumped to 0.0.6 with a breaking change, this pr bumps to 1.0.0 for semantic versioning.

# Manual QA steps
 - N/A
 
# Risks
 - low, bumps major version due to breaking change previously merged in
 
# Rollback steps
 - revert #5 and bump minor version
