### PR TITLE
meta data changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.0
+  * Added Parent stream for the child streams [#12](https://github.com/singer-io/tap-pepperjam/pull/12)
+
 ## 1.0.2
   * Bump dependency versions for twistlock compliance [#10](https://github.com/singer-io/tap-pepperjam/pull/10)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-pepperjam',
-      version='1.0.2',
+      version='1.1.0',
       description='Singer.io tap for extracting data from the Pepperjam Advertiser API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_pepperjam/schema.py
+++ b/tap_pepperjam/schema.py
@@ -31,6 +31,10 @@ def get_schemas():
             valid_replication_keys=stream_metadata.get('replication_keys', None),
             replication_method=stream_metadata.get('replication_method', None)
         )
+        parent_stream = stream_metadata.get('parent_stream')
+        if parent_stream:
+            mdata[0]['metadata'].update({"parent-tap-stream-id": parent_stream})
+
         field_metadata[stream_name] = mdata
 
     return schemas, field_metadata

--- a/tap_pepperjam/streams.py
+++ b/tap_pepperjam/streams.py
@@ -222,7 +222,8 @@ def flatten_streams():
         flat_streams[stream_name] = {
             'key_properties': endpoint_config.get('key_properties'),
             'replication_method': endpoint_config.get('replication_method'),
-            'replication_keys': endpoint_config.get('replication_keys')
+            'replication_keys': endpoint_config.get('replication_keys'),
+            'parent_stream': None
         }
         # Loop through children
         children = endpoint_config.get('children')
@@ -231,6 +232,7 @@ def flatten_streams():
                 flat_streams[child_stream_name] = {
                     'key_properties': child_enpoint_config.get('key_properties'),
                     'replication_method': child_enpoint_config.get('replication_method'),
-                    'replication_keys': child_enpoint_config.get('replication_keys')
+                    'replication_keys': child_enpoint_config.get('replication_keys'),
+                    'parent_stream': stream_name
                 }
     return flat_streams


### PR DESCRIPTION
# Description of change


This PR adds parent stream metadata tracking to the Pepperjam tap by introducing a new `parent_stream` field to stream configurations and updating metadata generation to include parent-tap-stream-id information.

Ticket : [SAC-28871](https://qlik-dev.atlassian.net/browse/SAC-28871)

- Added `parent_stream` field to stream configurations in the flattened streams structure
- Updated metadata generation to include parent-tap-stream-id when a parent stream exists


### Changes

| File | Description |
| ---- | ----------- |
| tap_pepperjam/streams.py | Added parent_stream field to both parent and child stream configurations |
| tap_pepperjam/schema.py | Updated metadata generation to include parent-tap-stream-id for child streams |





---

# Manual QA steps
You need to comment out the authentication (auth) part in a discovery function, and then generate a log file  to verify the changes.

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
